### PR TITLE
Ending

### DIFF
--- a/Assets/Scenes/ending.unity
+++ b/Assets/Scenes/ending.unity
@@ -4962,7 +4962,7 @@ Transform:
   - {fileID: 1889195467}
   - {fileID: 26206863}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &40730477
 AudioSource:
@@ -6328,7 +6328,7 @@ Transform:
   m_Children:
   - {fileID: 1427752825}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &850947606
 GameObject:

--- a/Assets/Scenes/ending.unity
+++ b/Assets/Scenes/ending.unity
@@ -5693,7 +5693,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 477121097}
         m_TargetAssemblyTypeName: MainScene, Assembly-CSharp
-        m_MethodName: ChangeScene
+        m_MethodName: Ending2Title
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Script/MainScene.cs
+++ b/Assets/Script/MainScene.cs
@@ -15,10 +15,14 @@ public class MainScene: MonoBehaviour {
         
     }
  
-    public void ChangeScene()
-    {
+    public void Ending2Title(){
         GameObject obj = GameObject.Find("Ending");
         Destroy(obj.gameObject, 5f);
+        ChangeScene();
+    }
+
+    public void ChangeScene()
+    {
         SceneManager.LoadScene("TitleScene");
     }
 }


### PR DESCRIPTION
`Main Scene.cs` において**ending以外のsceneから**TitleSceneに変更した際に`GameObject obj = null` となる問題を修正。

メソッド `Ending2Title()`を追加。
```C#
    public void Ending2Title(){
        GameObject obj = GameObject.Find("Ending");
        Destroy(obj.gameObject, 5f);
        ChangeScene();
    }
```